### PR TITLE
Wallet connect persistence

### DIFF
--- a/.changeset/honest-llamas-sing.md
+++ b/.changeset/honest-llamas-sing.md
@@ -1,0 +1,5 @@
+---
+"@simpleweb/open-format-react": patch
+---
+
+Persist wallet connection state

--- a/sdks/react/src/components/ConnectButton.tsx
+++ b/sdks/react/src/components/ConnectButton.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { useConnectWallet } from '@web3-onboard/react';
+import React, { useEffect } from 'react';
+import { useConnectWallet, useWallets } from '@web3-onboard/react';
+
+const STORAGE_KEY = '@OPEN_FORMAT/walletLables';
 
 interface Props extends React.ComponentProps<'button'> {
   labels?: {
@@ -22,8 +24,35 @@ export function ConnectButton({
     connect,
     disconnect,
   ] = useConnectWallet();
+  const wallets = useWallets();
 
   const isConnected = !!wallet;
+
+  useEffect(() => {
+    const getConnectedWallets = window.localStorage.getItem(STORAGE_KEY);
+
+    if (typeof getConnectedWallets === 'string') {
+      const walletLabels = JSON.parse(getConnectedWallets);
+
+      if (walletLabels.length) {
+        connect({
+          autoSelect: {
+            label: walletLabels[0],
+            disableModals: true,
+          },
+        });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (wallets.length) {
+      const walletLabels = wallets.map(({ label }) => label);
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(walletLabels));
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [wallets]);
 
   return (
     <button


### PR DESCRIPTION
This fixes #29.

The wallet you are connected is persisted to local storage so that upon refreshes/new pages it remains connected.