### PR TITLE
Contract address

### DIFF
--- a/.changeset/perfect-shoes-eat.md
+++ b/.changeset/perfect-shoes-eat.md
@@ -1,0 +1,5 @@
+---
+"@simpleweb/open-format": minor
+---
+
+Stores and allows configuration of a contract address

--- a/sdks/open-format/README.md
+++ b/sdks/open-format/README.md
@@ -65,18 +65,10 @@ await sdk.deploy({
 
 ### Minting an NFT
 
-Once you have the address of the deployed contract, you can then mint NFTs from it.
+Once your contract is deployed, you can then call `mint()`.
 
 ```tsx
-const { contractAddress } = await sdk.deploy({
-  maxSupply: 100,
-  mintingPrice: 0.01,
-  name: 'Test',
-  symbol: 'TEST',
-  url: 'ipfs://',
-});
-
-await sdk.mint({ contractAddress });
+await sdk.mint();
 ```
 
 ### Reading from the subgraph

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -58,26 +58,34 @@ export class OpenFormatSDK {
 
     await this.checkNetworksMatch();
 
-    return contract.deploy({
+    const tx = await contract.deploy({
       signer: this.signer,
       nft,
     });
+
+    this.options.contractAddress = tx.contractAddress;
+
+    return tx;
   }
 
   /**
    * Mints an NFT on a contract address
-   * @param {Object} options - options
-   * @param {string} options.contractAddress - The address of the contract to mint
    * @returns transaction
    */
-  async mint({ contractAddress }: { contractAddress: string }) {
+  async mint() {
+    if (!this.options.contractAddress) {
+      throw new Error('Contract address is required');
+    }
     if (!this.signer) {
       throw new Error('No signer set, aborting mint');
     }
 
     await this.checkNetworksMatch();
 
-    return contract.mint({ contractAddress, signer: this.signer });
+    return contract.mint({
+      contractAddress: this.options.contractAddress,
+      signer: this.signer,
+    });
   }
 
   rawRequest = subgraph.rawRequest;

--- a/sdks/open-format/src/types/index.ts
+++ b/sdks/open-format/src/types/index.ts
@@ -4,6 +4,7 @@ export interface SDKOptions {
   network: Chain;
   signer?: Signer | string;
   factory?: string;
+  contractAddress?: string;
 }
 
 export type Chain = 'mainnet' | 'mumbai' | 'localhost' | (string & {});

--- a/sdks/open-format/test/mint.test.ts
+++ b/sdks/open-format/test/mint.test.ts
@@ -11,7 +11,7 @@ describe('sdk.mint()', () => {
       ),
     });
 
-    const { contractAddress } = await sdk.deploy({
+    await sdk.deploy({
       maxSupply: 100,
       mintingPrice: 0.01,
       name: 'Test',
@@ -19,7 +19,7 @@ describe('sdk.mint()', () => {
       url: 'ipfs://',
     });
 
-    const receipt = await sdk.mint({ contractAddress });
+    const receipt = await sdk.mint();
 
     expect(receipt.status).toBe(1);
   });
@@ -27,11 +27,7 @@ describe('sdk.mint()', () => {
   it('will throw an error without a signer', () => {
     const sdk = new OpenFormatSDK({ network: 'http://localhost:8545' });
 
-    expect(
-      sdk.mint({
-        contractAddress: '0x...',
-      })
-    ).rejects.toThrow();
+    expect(sdk.mint()).rejects.toThrow();
   });
 
   it('will throw an error if the networks do not match', () => {
@@ -43,10 +39,6 @@ describe('sdk.mint()', () => {
       ),
     });
 
-    expect(
-      sdk.mint({
-        contractAddress: '0x...',
-      })
-    ).rejects.toThrow();
+    expect(sdk.mint()).rejects.toThrow();
   });
 });

--- a/sdks/open-format/test/sdk.test.ts
+++ b/sdks/open-format/test/sdk.test.ts
@@ -16,6 +16,18 @@ describe('sdk', () => {
     expect(network.chainId).toBe(80001);
   });
 
+  it('sets a contract address when one is passed', () => {
+    const sdk = new OpenFormatSDK({
+      network: 'mainnet',
+      contractAddress:
+        '0xc27786e23ac741aceef158731965a6285f350e114952201baad6149c18d735e7',
+    });
+
+    expect(sdk.options.contractAddress).toBe(
+      '0xc27786e23ac741aceef158731965a6285f350e114952201baad6149c18d735e7'
+    );
+  });
+
   it('will create a signer when a private key is passed as the signer option with a given network', async () => {
     const sdk = new OpenFormatSDK({
       network: 'mumbai',


### PR DESCRIPTION
As a contract address is going to be needed frequently, we need to store on the sdk instance. This changes the SDK so that you can pass a `contractAddress` when you initialise the SDK or it will store the `contractAddress` after you have a called the `deploy` function.

You used to have to do...

```tsx
const { contractAddress } = await sdk.deploy({
  maxSupply: 100,
  mintingPrice: 0.01,
  name: 'Test',
  symbol: 'TEST',
  url: 'ipfs://',
});

await sdk.mint({ contractAddress });
```

But now you can just do...

```tsx
await sdk.deploy({
  maxSupply: 100,
  mintingPrice: 0.01,
  name: 'Test',
  symbol: 'TEST',
  url: 'ipfs://',
});

await sdk.mint();
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
