### PR TITLE
Raw Request configuration options

### DIFF
--- a/.changeset/fluffy-rings-clean.md
+++ b/.changeset/fluffy-rings-clean.md
@@ -1,0 +1,5 @@
+---
+"@simpleweb/open-format-react": minor
+---
+
+Allows for react-query configuration options to be passed through when using the raw request hook

--- a/sdks/react/README.md
+++ b/sdks/react/README.md
@@ -70,6 +70,22 @@ function MyComponent() {
   return <>{data && <pre>{JSON.stringify(data, null, 2)}</pre>}</>;
 }
 ```
+#### Request Configuration
+
+[react-query](https://react-query.tanstack.com) is being used under the hood to make the request, and it is possible to pass through configuration options.
+
+```tsx
+const { data } = useRawRequest({
+  query: gql`
+    {
+      tokens {
+        id
+      }
+    }
+  `,
+  config: {...}
+});
+```
 
 ### Connecting to a wallet
 

--- a/sdks/react/src/hooks/useRawRequest.tsx
+++ b/sdks/react/src/hooks/useRawRequest.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from 'react-query';
+import { useQuery, UseQueryOptions } from 'react-query';
 import { useOpenFormat } from '../provider';
 
 /**
@@ -6,19 +6,26 @@ import { useOpenFormat } from '../provider';
  * @param {{ query: string }} options - a GraphQL query
  * @returns data from the subgraph
  */
-export function useRawRequest({
+export function useRawRequest<TQueryFnData, TError, TData = TQueryFnData>({
   query: rawQuery,
   variables,
+  config,
 }: {
   query: string;
   variables?: {
     [key: string]: any;
   };
+  config?: Omit<
+    UseQueryOptions<TQueryFnData, TError, TData>,
+    'queryKey' | 'queryFn'
+  >;
 }) {
   const { sdk } = useOpenFormat();
 
-  const query = useQuery(['raw-request', rawQuery], () =>
-    sdk.rawRequest(rawQuery, variables)
+  const query = useQuery(
+    ['raw-request', rawQuery],
+    () => sdk.rawRequest(rawQuery, variables),
+    config
   );
 
   return query;

--- a/sdks/react/test/useRawRequest.test.tsx
+++ b/sdks/react/test/useRawRequest.test.tsx
@@ -22,10 +22,45 @@ describe('useRawRequest', () => {
       '0x0667c3fa16ea85166e1d7fbe6da14031c6b541a1'
     );
   });
+
+  it('allows you to pass variables to a query', async () => {
+    render(<TestConfig />);
+
+    await waitFor(() => {
+      screen.getByTestId('tokenId');
+      screen.getByTestId('success');
+    });
+
+    expect(screen.getByTestId('tokenId')).toHaveTextContent(/0x/);
+    expect(screen.getByTestId('success')).toBeVisible();
+  });
 });
 
+function TestConfig() {
+  const [showSuccess, setShowSuccess] = React.useState(false);
+  const { data } = useRawRequest<any, any, any>({
+    query: gql`
+      {
+        tokens {
+          id
+        }
+      }
+    `,
+    config: {
+      onSuccess: () => setShowSuccess(true),
+    },
+  });
+
+  return (
+    <>
+      {data && <span data-testid="tokenId">{data?.tokens?.[0]?.id}</span>}
+      {showSuccess && <span data-testid="success">Success!</span>}
+    </>
+  );
+}
+
 function TestVariables() {
-  const { data } = useRawRequest({
+  const { data } = useRawRequest<any, any, any>({
     query: gql`
       query GetToken($id: String!) {
         token(id: $id) {
@@ -42,7 +77,7 @@ function TestVariables() {
 }
 
 function Test() {
-  const { data } = useRawRequest({
+  const { data } = useRawRequest<any, any, any>({
     query: gql`
       {
         tokens {


### PR DESCRIPTION
Allow React Query's config to be passed through with `rawRequest` - Fixes #46

## Raw Request: Configuration
```jsx
const { data } = useRawRequest<TQueryFnData, TError, TData>({
  query: gql`
    {
      tokens {
        id
      }
    }
  `,
  config: {
    onSuccess: () => console.log("onSuccess"),
  },
});
```

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset
