### PR TITLE
Fix: Ensures that networks do not conflict when testing in parallel

### DIFF
--- a/.changeset/green-beans-matter.md
+++ b/.changeset/green-beans-matter.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": patch
+"@simpleweb/open-format-react": patch
+---
+
+Ensures that networks do not conflict when testing SDKs in parallel

--- a/.changeset/green-beans-matter.md
+++ b/.changeset/green-beans-matter.md
@@ -1,6 +1,0 @@
----
-"@simpleweb/open-format": patch
-"@simpleweb/open-format-react": patch
----
-
-Ensures that networks do not conflict when testing SDKs in parallel

--- a/sdks/open-format/test/setup.ts
+++ b/sdks/open-format/test/setup.ts
@@ -23,7 +23,7 @@ export default function setup() {
     },
   });
 
-  (globalThis as any).__GANACHE__ = server;
+  (globalThis as any).__GANACHE_OPEN_FORMAT__ = server;
 
   return new Promise<void>((resolve, reject) => {
     server.listen(8545, error => {

--- a/sdks/open-format/test/teardown.ts
+++ b/sdks/open-format/test/teardown.ts
@@ -1,3 +1,3 @@
 export default async function teardown() {
-  (globalThis as any).__GANACHE__.close();
+  (globalThis as any).__GANACHE_OPEN_FORMAT__.close();
 }

--- a/sdks/react/src/utilities.tsx
+++ b/sdks/react/src/utilities.tsx
@@ -5,14 +5,14 @@ import { ethers } from 'ethers';
 
 const signer = new ethers.Wallet(
   '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
-  new ethers.providers.JsonRpcProvider('http://localhost:8545')
+  new ethers.providers.JsonRpcProvider('http://localhost:8546')
 );
 
 const App: FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
     <OpenFormatProvider
       config={{
-        network: 'localhost',
+        network: 'http://localhost:8546',
         factory: '1fe0b323-223f-48aa-8797-137931473f49',
         signer,
       }}

--- a/sdks/react/test/setup.ts
+++ b/sdks/react/test/setup.ts
@@ -23,10 +23,10 @@ export default function setup() {
     },
   });
 
-  (globalThis as any).__GANACHE__ = server;
+  (globalThis as any).__GANACHE_OPEN_FORMAT_REACT__ = server;
 
   return new Promise<void>((resolve, reject) => {
-    server.listen(8545, error => {
+    server.listen(8546, error => {
       if (error) {
         reject(error);
       }

--- a/sdks/react/test/teardown.ts
+++ b/sdks/react/test/teardown.ts
@@ -1,3 +1,3 @@
 export default async function teardown() {
-  (globalThis as any).__GANACHE__.close();
+  (globalThis as any).__GANACHE_OPEN_FORMAT_REACT__.close();
 }


### PR DESCRIPTION
# Fix Network Conflicts

* Ensures that networks do not conflict when running tests in parallel at the root of the project.
* Change ganache global scopes for each SDK
* Updates the react SDK test utilities to use a different port

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [ ] Code complete N/A
- [ ] Changeset N/A