### PR TITLE
Commissions: Set secondary commission

### DIFF
--- a/.changeset/hip-ducks-lick.md
+++ b/.changeset/hip-ducks-lick.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds the functionality to set the secondary commission percentage

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -181,6 +181,20 @@ export async function setPrimaryCommissionPercent({
   return receipt;
 }
 
+export async function setSecondaryCommissionPercent({
+  percent,
+  contractAddress,
+  signer,
+}: ContractArgs & { percent: BigNumberish }) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const tx = await openFormat.setSecondaryCommissionPct(percent);
+
+  const receipt = await tx.wait();
+
+  return receipt;
+}
+
 /**
  * Deploys a version of the Open Format contract
  * @private

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -264,12 +264,36 @@ export class OpenFormatSDK {
    * @returns
    */
   async setPrimaryCommissionPercent(percent: BigNumberish) {
-    invariant(this.signer, 'No signer set, aborting withdrawl of token funds');
+    invariant(
+      this.signer,
+      'No signer set, aborting set primary commission percent'
+    );
     invariant(this.options.contractAddress, 'No contract address set');
 
     await this.checkNetworksMatch();
 
     return contract.setPrimaryCommissionPercent({
+      percent,
+      contractAddress: this.options.contractAddress,
+      signer: this.signer,
+    });
+  }
+
+  /**
+   * Sets the percentages of the secondary commission
+   * @param {{ percent: BigNumberish; }} percent - Percent
+   * @returns
+   */
+  async setSecondaryCommissionPercent(percent: BigNumberish) {
+    invariant(
+      this.signer,
+      'No signer set, aborting set secondary commission percent'
+    );
+    invariant(this.options.contractAddress, 'No contract address set');
+
+    await this.checkNetworksMatch();
+
+    return contract.setSecondaryCommissionPercent({
       percent,
       contractAddress: this.options.contractAddress,
       signer: this.signer,

--- a/sdks/open-format/test/commission.test.ts
+++ b/sdks/open-format/test/commission.test.ts
@@ -27,4 +27,10 @@ describe('sdk commission', () => {
 
     expect(receipt?.status).toBe(1);
   });
+
+  it('sets the secondary commission percetnage', async () => {
+    const receipt = await sdk?.setSecondaryCommissionPercent(1000);
+
+    expect(receipt?.status).toBe(1);
+  });
 });

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './useRoyalties';
 export * from './useSaleData';
 export * from './useSetPrimaryCommissionPercentage';
 export * from './useSetRoyalties';
+export * from './useSetSecondaryCommissionPercentage';
 export * from './useTokens';
 export * from './useWallet';
 export * from './useWithdrawCollaboratorFunds';

--- a/sdks/react/src/hooks/useSetSecondaryCommissionPercentage.tsx
+++ b/sdks/react/src/hooks/useSetSecondaryCommissionPercentage.tsx
@@ -1,0 +1,22 @@
+import { useMutation } from 'react-query';
+import { useOpenFormat } from '../provider';
+
+export function useSetSecondaryCommissionPercentage() {
+  const { sdk } = useOpenFormat();
+
+  const {
+    mutateAsync: setSecondaryCommissionPercentage,
+    ...mutation
+  } = useMutation<
+    Awaited<ReturnType<typeof sdk.setSecondaryCommissionPercentage>>,
+    unknown,
+    Parameters<typeof sdk.setSecondaryCommissionPercentage>[0]
+  >(percent => {
+    return sdk.setSecondaryCommissionPercentage(percent);
+  });
+
+  return {
+    ...mutation,
+    setSecondaryCommissionPercentage,
+  };
+}

--- a/sdks/react/test/useSetSecondaryCommissionPercentage.test.tsx
+++ b/sdks/react/test/useSetSecondaryCommissionPercentage.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { useDeploy, useSetSecondaryCommissionPercentage } from '../src/hooks';
+import { render, screen, waitFor } from '../src/utilities';
+
+function Test() {
+  const { deploy, data: deployData } = useDeploy();
+  const {
+    setSecondaryCommissionPercentage,
+    data: secondaryCommissionData,
+  } = useSetSecondaryCommissionPercentage();
+
+  return (
+    <>
+      <button
+        data-testid="deploy"
+        onClick={() => {
+          deploy({
+            maxSupply: 100,
+            mintingPrice: 0.01,
+            name: 'Test',
+            symbol: 'TEST',
+            url: 'ipfs://',
+          });
+        }}
+      >
+        Deploy
+      </button>
+      {deployData && <div data-testid="deployData"></div>}
+
+      <button
+        data-testid="setSecondaryCommissionPercentage"
+        onClick={() => {
+          setSecondaryCommissionPercentage(500);
+        }}
+      >
+        set Secondary Commission Percentage
+      </button>
+
+      {secondaryCommissionData && (
+        <span data-testid="status">{secondaryCommissionData.status}</span>
+      )}
+    </>
+  );
+}
+
+describe('useSetSecondaryCommissionPercentage', () => {
+  it('allows you to set secondary commission percentage', async () => {
+    render(<Test />);
+
+    screen.getByTestId('deploy').click();
+    await waitFor(() => screen.getByTestId('deployData'));
+
+    screen.getByTestId('setSecondaryCommissionPercentage').click();
+    await waitFor(() => screen.getByTestId('status'));
+
+    expect(screen.getByTestId('status').innerHTML).toBe('1');
+  });
+});


### PR DESCRIPTION
Adds a new set secondary commission percentage function based on #42 

## Set Secondary Commission

In the main SDK you can now set the percentage of the secondary commission after you deploy.

```tsx
const receipt = await sdk?.setSecondaryCommissionPercent(1000);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
