### PR TITLE
Hotfix: Fix hook return types

### DIFF
--- a/.changeset/grumpy-drinks-admire.md
+++ b/.changeset/grumpy-drinks-admire.md
@@ -1,0 +1,5 @@
+---
+"@simpleweb/open-format-react": minor
+---
+
+Fixes the return types on some hooks

--- a/sdks/react/src/hooks/useRevenueSharingAllocation.tsx
+++ b/sdks/react/src/hooks/useRevenueSharingAllocation.tsx
@@ -5,7 +5,7 @@ export function useRevenueSharingAllocation() {
   const { sdk } = useOpenFormat();
 
   const { mutateAsync: allocate, ...mutation } = useMutation<
-    Awaited<ReturnType<typeof sdk.setupRevenueSharing>>,
+    Awaited<ReturnType<typeof sdk.allocateRevenueShares>>,
     unknown,
     Parameters<typeof sdk.allocateRevenueShares>[0]
   >(params => {

--- a/sdks/react/src/hooks/useWithdrawCollaboratorFunds.tsx
+++ b/sdks/react/src/hooks/useWithdrawCollaboratorFunds.tsx
@@ -5,7 +5,7 @@ export function useWithdrawCollaboratorFunds() {
   const { sdk } = useOpenFormat();
 
   const { mutateAsync: withdraw, ...mutation } = useMutation<
-    Awaited<ReturnType<typeof sdk.setupRevenueSharing>>,
+    Awaited<ReturnType<typeof sdk.withdrawCollaboratorFunds>>,
     unknown,
     Parameters<typeof sdk.withdrawCollaboratorFunds>[0]
   >(params => {

--- a/sdks/react/src/hooks/useWithdrawTokenFunds.tsx
+++ b/sdks/react/src/hooks/useWithdrawTokenFunds.tsx
@@ -5,7 +5,7 @@ export function useWithdrawTokenFunds() {
   const { sdk } = useOpenFormat();
 
   const { mutateAsync: withdraw, ...mutation } = useMutation<
-    Awaited<ReturnType<typeof sdk.setupRevenueSharing>>,
+    Awaited<ReturnType<typeof sdk.withdrawTokenFunds>>,
     unknown,
     Parameters<typeof sdk.withdrawTokenFunds>[0]
   >(params => {


### PR DESCRIPTION
Updates the return types for the following hooks:

* `useRevenueSharingAllocation`
* `useWithdrawCollaboratorFunds`
* `useWithdrawTokenFunds`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
