### PR TITLE
Secondary Sales: Buy

### DIFF
--- a/.changeset/calm-ligers-worry.md
+++ b/.changeset/calm-ligers-worry.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds the functionality to buy

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -230,6 +230,24 @@ export async function setTokenSalePrice({
   return receipt;
 }
 
+export async function buy({
+  tokenId,
+  contractAddress,
+  signer,
+}: ContractArgs & { tokenId: BigNumberish }) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const tokenSalePrice = await openFormat.getTokenSalePrice(tokenId);
+
+  const tx = await openFormat['buy(uint256)'](tokenId, {
+    value: tokenSalePrice,
+  });
+
+  const receipt = await tx.wait();
+
+  return receipt;
+}
+
 export async function buyWithCommission({
   tokenId,
   address,

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -339,6 +339,25 @@ export class OpenFormatSDK {
   }
 
   /**
+   * Buy
+   * @param {Object} params
+   * @param {number} params.tokenId - id of the token
+   * @returns
+   */
+  async buy(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set, aborting buy');
+    invariant(this.options.contractAddress, 'No contract address set');
+
+    await this.checkNetworksMatch();
+
+    return contract.buy({
+      tokenId,
+      contractAddress: this.options.contractAddress,
+      signer: this.signer,
+    });
+  }
+
+  /**
    * Buy with commission
    * @param {Object} params
    * @param {number} params.tokenId - id of the token
@@ -352,10 +371,7 @@ export class OpenFormatSDK {
     tokenId: BigNumberish;
     address: string;
   }) {
-    invariant(
-      this.signer,
-      'No signer set, aborting set secondary commission percent'
-    );
+    invariant(this.signer, 'No signer set, aborting buy with commission');
     invariant(this.options.contractAddress, 'No contract address set');
 
     await this.checkNetworksMatch();

--- a/sdks/open-format/test/buy.test.ts
+++ b/sdks/open-format/test/buy.test.ts
@@ -1,0 +1,34 @@
+import { ethers } from 'ethers';
+import { OpenFormatSDK } from '../src/index';
+
+describe('sdk buy', () => {
+  let sdk: null | OpenFormatSDK = null;
+
+  beforeEach(async () => {
+    sdk = new OpenFormatSDK({
+      network: 'http://localhost:8545',
+      signer: new ethers.Wallet(
+        '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
+        new ethers.providers.JsonRpcProvider('http://localhost:8545')
+      ),
+    });
+
+    await sdk.deploy({
+      maxSupply: 100,
+      mintingPrice: 0.01,
+      name: 'Test',
+      symbol: 'TEST',
+      url: 'ipfs://',
+    });
+
+    await sdk?.mint();
+  });
+
+  it('buy', async () => {
+    await sdk?.setTokenSalePrice({ tokenId: 0, price: 1000 });
+
+    const receipt = await sdk?.buy(0);
+
+    expect(receipt?.status).toBe(1);
+  });
+});

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useBuy';
 export * from './useBuyWithCommission';
 export * from './useDeploy';
 export * from './useGetCollaboratorBalance';

--- a/sdks/react/src/hooks/useBuy.tsx
+++ b/sdks/react/src/hooks/useBuy.tsx
@@ -1,0 +1,19 @@
+import { useMutation } from 'react-query';
+import { useOpenFormat } from '../provider';
+
+export function useBuy() {
+  const { sdk } = useOpenFormat();
+
+  const { mutateAsync, ...mutation } = useMutation<
+    Awaited<ReturnType<typeof sdk.buy>>,
+    unknown,
+    Parameters<typeof sdk.buy>[0]
+  >(data => {
+    return sdk.buy(data);
+  });
+
+  return {
+    ...mutation,
+    buy: mutateAsync,
+  };
+}

--- a/sdks/react/test/useBuy.test.tsx
+++ b/sdks/react/test/useBuy.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom';
+import { useDeploy, useMint, useSetTokenSalePrice, useBuy } from '../src/hooks';
+import { render, screen, waitFor } from '../src/utilities';
+import React from 'react';
+
+function Buy() {
+  const { setTokenSalePrice } = useSetTokenSalePrice();
+  const { buy, data } = useBuy();
+
+  const onBuy = async () => {
+    await setTokenSalePrice({ tokenId: 0, price: 1000 });
+
+    await buy(0);
+  };
+
+  return (
+    <>
+      <button data-testid="buy" onClick={onBuy}>
+        Buy
+      </button>
+      {data && <span data-testid="buyData"></span>}
+    </>
+  );
+}
+
+function Test() {
+  const { deploy, data: deployData } = useDeploy();
+  const { mint, data } = useMint();
+
+  return (
+    <>
+      <button
+        data-testid="deploy"
+        onClick={() => {
+          deploy({
+            maxSupply: 100,
+            mintingPrice: 0.01,
+            name: 'Test',
+            symbol: 'TEST',
+            url: 'ipfs://',
+          });
+        }}
+      >
+        Deploy
+      </button>
+      {deployData && <div data-testid="deployData"></div>}
+
+      <button data-testid="mint" onClick={() => mint()}>
+        Mint
+      </button>
+      {data && (
+        <>
+          <span data-testid="mintData"></span>
+          <Buy />
+        </>
+      )}
+    </>
+  );
+}
+
+describe('useBuy', () => {
+  it('allows you to buy', async () => {
+    render(<Test />);
+
+    screen.getByTestId('deploy').click();
+    await waitFor(() => screen.getByTestId('deployData'));
+
+    screen.getByTestId('mint').click();
+    await waitFor(() => screen.getByTestId('mintData'));
+
+    screen.getByTestId('buy').click();
+    await waitFor(() => screen.getByTestId('buyData'));
+  });
+});


### PR DESCRIPTION
Adds a new buy function based on #42 

## Buy

In the main SDK you can now buy after you deploy.

```tsx
const receipt = await sdk?.buy(0);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
