### PR TITLE
Add link to react docs

### DIFF
--- a/sdks/react/README.md
+++ b/sdks/react/README.md
@@ -16,7 +16,7 @@ yarn add @simpleweb/open-format-react ethers
 
 ## Documentation
 
-@TODO: Add link to documentation when it exists
+[View the docs](https://docs.openformat.simpleweb.co.uk/sdk/react)
 
 You can [checkout an example Next.js to see how it works](https://github.com/simpleweb/open-format/tree/main/examples/react-next).
 


### PR DESCRIPTION
Adds a link to the react docs on gitbook

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
