### PR TITLE
Feature: Get Commission Percentage

### DIFF
--- a/.changeset/strange-cobras-battle.md
+++ b/.changeset/strange-cobras-battle.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds in functionality to get the primary and secondary commission percentage

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -201,6 +201,17 @@ export async function setPrimaryCommissionPercent({
   return receipt;
 }
 
+export async function getPrimaryCommissionPercent({
+  contractAddress,
+  signer,
+}: ContractArgs) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const percent = await openFormat.getPrimaryCommissionPct();
+
+  return percent;
+}
+
 export async function setSecondaryCommissionPercent({
   percent,
   contractAddress,
@@ -213,6 +224,17 @@ export async function setSecondaryCommissionPercent({
   const receipt = await tx.wait();
 
   return receipt;
+}
+
+export async function getSecondaryCommissionPercent({
+  contractAddress,
+  signer,
+}: ContractArgs) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const percent = await openFormat.getSecondaryCommissionPct();
+
+  return percent;
 }
 
 export async function setTokenSalePrice({

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -206,7 +206,20 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   /**
-   * Sets the percentages of the secondary commission
+   * Gets the percentage of the primary commission
+   * @returns percent
+   */
+  async getPrimaryCommissionPercent() {
+    await this.checkNetworksMatch();
+
+    return contract.getPrimaryCommissionPercent({
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
+   * Sets the percentage of the secondary commission
    * @param {BigNumberish} percent - Percent
    * @returns
    */
@@ -215,6 +228,19 @@ export class OpenFormatNFT extends BaseContract {
 
     return contract.setSecondaryCommissionPercent({
       percent,
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
+   * Gets the percentage of the secondary commission
+   * @returns percent
+   */
+  async getSecondaryCommissionPercent() {
+    await this.checkNetworksMatch();
+
+    return contract.getSecondaryCommissionPercent({
       contractAddress: this.address,
       signer: this.signer,
     });

--- a/sdks/open-format/test/commission.test.ts
+++ b/sdks/open-format/test/commission.test.ts
@@ -44,7 +44,7 @@ describe('sdk commission', () => {
     expect(receipt?.status).toBe(1);
   });
 
-  it('gets the primary commission percetnage', async () => {
+  it('gets the secondary commission percetnage', async () => {
     const receipt = await nft.getSecondaryCommissionPercent();
 
     expect(receipt).toBeInstanceOf(BigNumber);

--- a/sdks/open-format/test/commission.test.ts
+++ b/sdks/open-format/test/commission.test.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { OpenFormatNFT } from '../src/core/nft';
 import { OpenFormatSDK } from '../src/index';
 
@@ -32,10 +32,22 @@ describe('sdk commission', () => {
     expect(receipt?.status).toBe(1);
   });
 
+  it('gets the primary commission percetnage', async () => {
+    const receipt = await nft.getPrimaryCommissionPercent();
+
+    expect(receipt).toBeInstanceOf(BigNumber);
+  });
+
   it('sets the secondary commission percetnage', async () => {
     const receipt = await nft.setSecondaryCommissionPercent(1000);
 
     expect(receipt?.status).toBe(1);
+  });
+
+  it('gets the primary commission percetnage', async () => {
+    const receipt = await nft.getSecondaryCommissionPercent();
+
+    expect(receipt).toBeInstanceOf(BigNumber);
   });
 
   it('mints with commission', async () => {

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -2,6 +2,8 @@ export * from './useBuy';
 export * from './useBuyWithCommission';
 export * from './useDeploy';
 export * from './useGetCollaboratorBalance';
+export * from './useGetPrimaryCommissionPercentage';
+export * from './useGetSecondaryCommissionPercentage';
 export * from './useGetTokenBalance';
 export * from './useMint';
 export * from './useMintWithCommission';

--- a/sdks/react/src/hooks/useGetPrimaryCommissionPercentage.tsx
+++ b/sdks/react/src/hooks/useGetPrimaryCommissionPercentage.tsx
@@ -1,0 +1,11 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { useQuery } from 'react-query';
+
+export function useGetPrimaryCommissionPercent(nft: OpenFormatNFT) {
+  const query = useQuery<
+    Awaited<ReturnType<typeof nft.getPrimaryCommissionPercent>>,
+    unknown
+  >(['primary-commission'], () => nft.getPrimaryCommissionPercent());
+
+  return query;
+}

--- a/sdks/react/src/hooks/useGetSecondaryCommissionPercentage.tsx
+++ b/sdks/react/src/hooks/useGetSecondaryCommissionPercentage.tsx
@@ -1,0 +1,11 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { useQuery } from 'react-query';
+
+export function useGetSecondaryCommissionPercent(nft: OpenFormatNFT) {
+  const query = useQuery<
+    Awaited<ReturnType<typeof nft.getSecondaryCommissionPercent>>,
+    unknown
+  >(['secondary-commission'], () => nft.getSecondaryCommissionPercent());
+
+  return query;
+}

--- a/sdks/react/test/useGetPrimaryCommissionPercentage.test.tsx
+++ b/sdks/react/test/useGetPrimaryCommissionPercentage.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { BigNumber } from 'ethers';
+import { useNFT, useGetPrimaryCommissionPercent } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function GetCommission({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { data, isSuccess } = useGetPrimaryCommissionPercent(nft);
+
+  return (
+    <>{isSuccess && <span data-testid="status">{data.toString()}</span>}</>
+  );
+}
+
+describe('useGetPrimaryCommissionPercentage', () => {
+  it('allows you to get primary commission percentage', async () => {
+    render(
+      <DeployedTest>
+        {({ address }) => <GetCommission address={address} />}
+      </DeployedTest>
+    );
+
+    await waitFor(() => screen.getByTestId('status'));
+
+    expect(screen.getByTestId('status').innerHTML).toBeInstanceOf(BigNumber);
+  });
+});

--- a/sdks/react/test/useGetSecondaryCommissionPercentage.test.tsx
+++ b/sdks/react/test/useGetSecondaryCommissionPercentage.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { BigNumber } from 'ethers';
+import { useNFT, useGetSecondaryCommissionPercent } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function GetCommission({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { data, isSuccess } = useGetSecondaryCommissionPercent(nft);
+
+  return (
+    <>{isSuccess && <span data-testid="status">{data.toString()}</span>}</>
+  );
+}
+
+describe('useGetSecondaryCommissionPercentage', () => {
+  it('allows you to get secondary commission percentage', async () => {
+    render(
+      <DeployedTest>
+        {({ address }) => <GetCommission address={address} />}
+      </DeployedTest>
+    );
+
+    await waitFor(() => screen.getByTestId('status'));
+
+    expect(screen.getByTestId('status').innerHTML).toBeInstanceOf(BigNumber);
+  });
+});


### PR DESCRIPTION
# Get Commission Percentage

Introduces the `getPrimaryCommissionPercent` and `getSecondaryCommissionPercent` into the SDK, as per the discussion thread #61.

```tsx
const nft = sdk.getNFT(contractAddress);
const receipt = await nft.getPrimaryCommissionPercent();
const receipt = await nft.getSecondaryCommissionPercent();
```

```tsx
const nft = useNFT(address);
const { data: primaryCommissionPercent } = useGetPrimaryCommissionPercent(nft);
const { data: secondaryCommissionPercent } = useGetSecondaryCommissionPercent(nft);
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
