### PR TITLE
Feature: Get Token Sale Price

### DIFF
--- a/.changeset/fast-jokes-mate.md
+++ b/.changeset/fast-jokes-mate.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds in functionality to allow you to get the token sale price

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -162,25 +162,25 @@ export async function getCollaboratorBalance({
 }
 
 export async function getTokenBalance({
-  token,
+  tokenId,
   contractAddress,
   signer,
-}: ContractArgs & { token: BigNumberish }) {
+}: ContractArgs & { tokenId: BigNumberish }) {
   const openFormat = getContract({ contractAddress, signer });
 
-  const balance = await openFormat.getSingleTokenBalance(token);
+  const balance = await openFormat.getSingleTokenBalance(tokenId);
 
   return balance;
 }
 
 export async function withdrawTokenFunds({
-  token,
+  tokenId,
   contractAddress,
   signer,
-}: ContractArgs & { token: BigNumberish }) {
+}: ContractArgs & { tokenId: BigNumberish }) {
   const openFormat = getContract({ contractAddress, signer });
 
-  const tx = await openFormat['withdraw(uint256)'](token);
+  const tx = await openFormat['withdraw(uint256)'](tokenId);
 
   const receipt = await tx.wait();
 
@@ -250,6 +250,18 @@ export async function setTokenSalePrice({
   const receipt = await tx.wait();
 
   return receipt;
+}
+
+export async function getTokenSalePrice({
+  tokenId,
+  contractAddress,
+  signer,
+}: ContractArgs & { tokenId: BigNumberish }) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const price = await openFormat.getTokenSalePrice(tokenId);
+
+  return price;
 }
 
 export async function buy({

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -162,14 +162,14 @@ export class OpenFormatNFT extends BaseContract {
 
   /**
    * Get the balance of a token
-   * @param {BigNumberish} token - Token number
+   * @param {BigNumberish} tokenId - Id of the token
    * @returns BigNumber
    */
-  async getTokenBalance(token: BigNumberish) {
+  async getTokenBalance(tokenId: BigNumberish) {
     await this.checkNetworksMatch();
 
     return contract.getTokenBalance({
-      token,
+      tokenId,
       contractAddress: this.address,
       signer: this.signer,
     });
@@ -177,14 +177,14 @@ export class OpenFormatNFT extends BaseContract {
 
   /**
    * Withdrawl of token funds
-   * @param {BigNumberish} token - Token number
+   * @param {BigNumberish} tokenId - Id of the token
    * @returns
    */
-  async withdrawTokenFunds(token: BigNumberish) {
+  async withdrawTokenFunds(tokenId: BigNumberish) {
     await this.checkNetworksMatch();
 
     return contract.withdrawTokenFunds({
-      token,
+      tokenId,
       contractAddress: this.address,
       signer: this.signer,
     });
@@ -192,7 +192,7 @@ export class OpenFormatNFT extends BaseContract {
 
   /**
    * Sets the percentage of the primary commission
-   * @param {{ percent: BigNumberish; }} percent - Percent
+   * @param {BigNumberish} percent - Percent of primary commission
    * @returns
    */
   async setPrimaryCommissionPercent(percent: BigNumberish) {
@@ -220,7 +220,7 @@ export class OpenFormatNFT extends BaseContract {
 
   /**
    * Sets the percentage of the secondary commission
-   * @param {BigNumberish} percent - Percent
+   * @param {BigNumberish} percent - Percent of secondary commission
    * @returns
    */
   async setSecondaryCommissionPercent(percent: BigNumberish) {
@@ -246,6 +246,13 @@ export class OpenFormatNFT extends BaseContract {
     });
   }
 
+  /**
+   * Sets the token sale price
+   * @param {Object} params
+   * @param {BigNumberish} params.tokenId - Id of the token
+   * @param {BigNumberish} params.price - Price of the token
+   * @returns
+   */
   async setTokenSalePrice({
     tokenId,
     price,
@@ -264,9 +271,24 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   /**
+   * Gets the token sale price
+   * @param {BigNumberish} tokenId - Id of the token
+   * @returns price
+   */
+  async getTokenSalePrice(tokenId: BigNumberish) {
+    await this.checkNetworksMatch();
+
+    return contract.getTokenSalePrice({
+      tokenId,
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
    * Buy
    * @param {Object} params
-   * @param {number} params.tokenId - id of the token
+   * @param {BigNumberish} params.tokenId - id of the token
    * @returns
    */
   async buy(tokenId: BigNumberish) {
@@ -282,7 +304,7 @@ export class OpenFormatNFT extends BaseContract {
   /**
    * Buy with commission
    * @param {Object} params
-   * @param {number} params.tokenId - id of the token
+   * @param {BigNumberish} params.tokenId - id of the token
    * @param {number} params.address - Address
    * @returns
    */

--- a/sdks/open-format/test/token.test.ts
+++ b/sdks/open-format/test/token.test.ts
@@ -1,0 +1,42 @@
+import { BigNumber, ethers } from 'ethers';
+import { OpenFormatNFT } from '../src/core/nft';
+import { OpenFormatSDK } from '../src/index';
+
+describe('sdk token', () => {
+  let sdk: null | OpenFormatSDK = null;
+  let nft: OpenFormatNFT;
+
+  beforeEach(async () => {
+    sdk = new OpenFormatSDK({
+      network: 'http://localhost:8545',
+      signer: new ethers.Wallet(
+        '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
+        new ethers.providers.JsonRpcProvider('http://localhost:8545')
+      ),
+    });
+
+    const { contractAddress } = await sdk.deploy({
+      maxSupply: 100,
+      mintingPrice: 0.01,
+      name: 'Test',
+      symbol: 'TEST',
+      url: 'ipfs://',
+    });
+
+    nft = sdk.getNFT(contractAddress);
+
+    await nft.mint();
+  });
+
+  it('set token sale price', async () => {
+    const receipt = await nft.setTokenSalePrice({ tokenId: 0, price: 1000 });
+
+    expect(receipt?.status).toBe(1);
+  });
+
+  it('get token sale price', async () => {
+    const price = await nft.getTokenSalePrice(0);
+
+    expect(price).toBeInstanceOf(BigNumber);
+  });
+});

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from './useGetCollaboratorBalance';
 export * from './useGetPrimaryCommissionPercentage';
 export * from './useGetSecondaryCommissionPercentage';
 export * from './useGetTokenBalance';
+export * from './useGetTokenSalePrice';
 export * from './useMint';
 export * from './useMintWithCommission';
 export * from './useNFT';

--- a/sdks/react/src/hooks/useGetPrimaryCommissionPercentage.tsx
+++ b/sdks/react/src/hooks/useGetPrimaryCommissionPercentage.tsx
@@ -1,6 +1,10 @@
 import { OpenFormatNFT } from '@simpleweb/open-format';
 import { useQuery } from 'react-query';
 
+/**
+ * Hook to get primary commission percentage
+ * @returns BigNumber
+ */
 export function useGetPrimaryCommissionPercent(nft: OpenFormatNFT) {
   const query = useQuery<
     Awaited<ReturnType<typeof nft.getPrimaryCommissionPercent>>,

--- a/sdks/react/src/hooks/useGetSecondaryCommissionPercentage.tsx
+++ b/sdks/react/src/hooks/useGetSecondaryCommissionPercentage.tsx
@@ -1,6 +1,10 @@
 import { OpenFormatNFT } from '@simpleweb/open-format';
 import { useQuery } from 'react-query';
 
+/**
+ * Hook to get secondary commission percentage
+ * @returns BigNumber
+ */
 export function useGetSecondaryCommissionPercent(nft: OpenFormatNFT) {
   const query = useQuery<
     Awaited<ReturnType<typeof nft.getSecondaryCommissionPercent>>,

--- a/sdks/react/src/hooks/useGetTokenSalePrice.tsx
+++ b/sdks/react/src/hooks/useGetTokenSalePrice.tsx
@@ -1,0 +1,16 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { BigNumberish } from 'ethers';
+import { useQuery } from 'react-query';
+
+/**
+ * Hook to get sale price for a token
+ * @param {{ token: BigNumberish }} token - Token ID
+ * @returns BigNumber
+ */
+export function useGetTokenSalePrice(nft: OpenFormatNFT, token: BigNumberish) {
+  const query = useQuery(['getTokenSalePrice', token], () =>
+    nft.getTokenSalePrice(token)
+  );
+
+  return query;
+}

--- a/sdks/react/test/useGetTokenSalePrice.test.tsx
+++ b/sdks/react/test/useGetTokenSalePrice.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { useMint, useNFT, useGetTokenSalePrice } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function Get({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { mint, data: mintData } = useMint(nft);
+  const { data } = useGetTokenSalePrice(nft, 0);
+
+  return (
+    <>
+      <button data-testid="mint" onClick={() => mint()}>
+        Mint
+      </button>
+
+      {mintData && (
+        <>
+          <span data-testid="mintData"></span>
+          {data && <span data-testid="getData"></span>}
+        </>
+      )}
+    </>
+  );
+}
+
+describe('useGetTokenSalePrice', () => {
+  it('allows you to get the token sale price', async () => {
+    render(
+      <DeployedTest>{({ address }) => <Get address={address} />}</DeployedTest>
+    );
+
+    const mintButton = await waitFor(() => screen.getByTestId('mint'));
+
+    mintButton.click();
+    await waitFor(() => screen.getByTestId('mintData'));
+
+    await waitFor(() => screen.getByTestId('getData'));
+  });
+});

--- a/sdks/react/test/useSetTokenSalePrice.test.tsx
+++ b/sdks/react/test/useSetTokenSalePrice.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { useMint, useNFT, useSetTokenSalePrice } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function Set({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { mint, data: mintData } = useMint(nft);
+  const { setTokenSalePrice, data } = useSetTokenSalePrice(nft);
+
+  const onSet = async () => {
+    await setTokenSalePrice({ tokenId: 0, price: 1000 });
+  };
+
+  return (
+    <>
+      <button data-testid="mint" onClick={() => mint()}>
+        Mint
+      </button>
+
+      {mintData && (
+        <>
+          <span data-testid="mintData"></span>
+          <button data-testid="set" onClick={onSet}>
+            Set Price
+          </button>
+        </>
+      )}
+
+      {data && <span data-testid="setData"></span>}
+    </>
+  );
+}
+
+describe('useSetTokenSalePrice', () => {
+  it('allows you to set the token sale price', async () => {
+    render(
+      <DeployedTest>{({ address }) => <Set address={address} />}</DeployedTest>
+    );
+
+    const mintButton = await waitFor(() => screen.getByTestId('mint'));
+
+    mintButton.click();
+    await waitFor(() => screen.getByTestId('mintData'));
+
+    screen.getByTestId('set').click();
+    await waitFor(() => screen.getByTestId('setData'));
+  });
+});


### PR DESCRIPTION
# Get Token Sale Price

Introduces `getTokenSalePrice` into the SDK, as per the discussion thread #61.

```tsx
const nft = sdk.getNFT(contractAddress);
const price = await nft.getTokenSalePrice(0);
```

```tsx
const nft = useNFT(address);
const { data } = useGetTokenSalePrice(nft, 0);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
