### PR TITLE
Feature: Set Minting Price

### DIFF
--- a/.changeset/shy-eagles-flash.md
+++ b/.changeset/shy-eagles-flash.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds in functionality to allow you to set the price of minting

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -47,6 +47,22 @@ export async function mintWithCommission({
   return receipt;
 }
 
+export async function setMintingPrice({
+  price,
+  contractAddress,
+  signer,
+}: ContractArgs & {
+  price: BigNumberish;
+}) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const tx = await openFormat.setMintingPrice(price);
+
+  const receipt = await tx.wait();
+
+  return receipt;
+}
+
 export async function setRoyalties({
   contractAddress,
   signer,

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -44,6 +44,21 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   /**
+   * Mints an NFT with commission on a contract address
+   * @param {BigNumberish} price - mint price to set
+   * @returns transaction
+   */
+  async setMintingPrice(price: BigNumberish) {
+    await this.checkNetworksMatch();
+
+    return contract.setMintingPrice({
+      price,
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
    * Setup royalties to be paid to an address
    * @param {Object} params
    * @param {number} params.royaltyReceiverAddress - address of the receiver of the royalties

--- a/sdks/open-format/test/mint.test.ts
+++ b/sdks/open-format/test/mint.test.ts
@@ -1,9 +1,13 @@
 import { ethers } from 'ethers';
+import { OpenFormatNFT } from '../src/core/nft';
 import { OpenFormatSDK } from '../src/index';
 
 describe('sdk.mint()', () => {
-  it('mints an NFT of a deployed contract', async () => {
-    const sdk = new OpenFormatSDK({
+  let sdk: null | OpenFormatSDK = null;
+  let nft: OpenFormatNFT;
+
+  beforeEach(async () => {
+    sdk = new OpenFormatSDK({
       network: 'http://localhost:8545',
       signer: new ethers.Wallet(
         '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
@@ -19,32 +23,16 @@ describe('sdk.mint()', () => {
       url: 'ipfs://',
     });
 
-    const nft = sdk.getNFT(contractAddress);
+    nft = sdk.getNFT(contractAddress);
+  });
 
+  it('mints an NFT of a deployed contract', async () => {
     const receipt = await nft.mint();
 
     expect(receipt.status).toBe(1);
   });
 
   it('will throw an error if the networks do not match', async () => {
-    const sdk = new OpenFormatSDK({
-      network: 'http://localhost:8545',
-      signer: new ethers.Wallet(
-        '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
-        new ethers.providers.JsonRpcProvider('http://localhost:8545')
-      ),
-    });
-
-    const { contractAddress } = await sdk.deploy({
-      maxSupply: 100,
-      mintingPrice: 0.01,
-      name: 'Test',
-      symbol: 'TEST',
-      url: 'ipfs://',
-    });
-
-    const nft = sdk.getNFT(contractAddress);
-
     nft.signer = new ethers.Wallet(
       '0x04c65fb1737cf9a5fb605b403b5027924309e53a3433d06029a0441cc03e2042',
       new ethers.providers.JsonRpcProvider(
@@ -53,5 +41,11 @@ describe('sdk.mint()', () => {
     );
 
     expect(nft.mint()).rejects.toThrow();
+  });
+
+  it('sets the price of minting', async () => {
+    const receipt = await nft.setMintingPrice(1000);
+
+    expect(receipt.status).toBe(1);
   });
 });

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from './useRawRequest';
 export * from './useRevenueSharingAllocation';
 export * from './useRoyalties';
 export * from './useSaleData';
+export * from './useSetMintingPrice';
 export * from './useSetPrimaryCommissionPercentage';
 export * from './useSetRoyalties';
 export * from './useSetSecondaryCommissionPercentage';

--- a/sdks/react/src/hooks/useSetMintingPrice.tsx
+++ b/sdks/react/src/hooks/useSetMintingPrice.tsx
@@ -1,0 +1,17 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { useMutation } from 'react-query';
+
+export function useSetMintingPrice(nft: OpenFormatNFT) {
+  const { mutateAsync: setMintingPrice, ...mutation } = useMutation<
+    Awaited<ReturnType<typeof nft.setMintingPrice>>,
+    unknown,
+    Parameters<typeof nft.setMintingPrice>[0]
+  >(price => {
+    return nft.setMintingPrice(price);
+  });
+
+  return {
+    ...mutation,
+    setMintingPrice,
+  };
+}

--- a/sdks/react/test/useSetMintingPrice.test.tsx
+++ b/sdks/react/test/useSetMintingPrice.test.tsx
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { useNFT, useSetMintingPrice } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function Set({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { setMintingPrice, data: mintingPriceData } = useSetMintingPrice(nft);
+
+  return (
+    <>
+      <button
+        data-testid="setMintingPrice"
+        onClick={() => {
+          setMintingPrice(1000);
+        }}
+      >
+        Set Minting Price
+      </button>
+
+      {mintingPriceData && (
+        <span data-testid="status">{mintingPriceData.status}</span>
+      )}
+    </>
+  );
+}
+
+describe('useSetMintingPrice', () => {
+  it('allows you to set minting price', async () => {
+    render(
+      <DeployedTest>{({ address }) => <Set address={address} />}</DeployedTest>
+    );
+
+    const set = await waitFor(() => screen.getByTestId('setMintingPrice'));
+
+    set.click();
+    await waitFor(() => screen.getByTestId('status'));
+
+    expect(screen.getByTestId('status').innerHTML).toBe('1');
+  });
+});


### PR DESCRIPTION
# Set Minting Price

Introduces `setMintingPrice` into the SDK, as per the discussion thread #61.

```tsx
const nft = sdk.getNFT(contractAddress);
const receipt = await nft.setMintingPrice(1000);
```

```tsx
const nft = useNFT(address);
const { setMintingPrice } = useSetMintingPrice(nft);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
