### PR TITLE
Feature: Get Token Creator

### DIFF
--- a/.changeset/light-seas-kiss.md
+++ b/.changeset/light-seas-kiss.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds in functionality to allow you to get the creator of a token

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -177,18 +177,6 @@ export async function getCollaboratorBalance({
   return balance;
 }
 
-export async function getTokenBalance({
-  tokenId,
-  contractAddress,
-  signer,
-}: ContractArgs & { tokenId: BigNumberish }) {
-  const openFormat = getContract({ contractAddress, signer });
-
-  const balance = await openFormat.getSingleTokenBalance(tokenId);
-
-  return balance;
-}
-
 export async function withdrawTokenFunds({
   tokenId,
   contractAddress,
@@ -201,6 +189,18 @@ export async function withdrawTokenFunds({
   const receipt = await tx.wait();
 
   return receipt;
+}
+
+export async function getTokenBalance({
+  tokenId,
+  contractAddress,
+  signer,
+}: ContractArgs & { tokenId: BigNumberish }) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const balance = await openFormat.getSingleTokenBalance(tokenId);
+
+  return balance;
 }
 
 export async function setPrimaryCommissionPercent({
@@ -266,6 +266,21 @@ export async function setTokenSalePrice({
   const receipt = await tx.wait();
 
   return receipt;
+}
+
+export async function getTokenCreator({
+  tokenId,
+  contractAddress,
+  signer,
+}: ContractArgs & { tokenId: BigNumberish }) {
+  const openFormat = getContract({
+    contractAddress,
+    signer,
+  });
+
+  const creator = await openFormat.creatorOf(tokenId);
+
+  return creator;
 }
 
 export async function getTokenSalePrice({

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -301,6 +301,21 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   /**
+   * Gets the creator of a token
+   * @param {BigNumberish} tokenId - Id of the token
+   * @returns creator
+   */
+  async getTokenCreator(tokenId: BigNumberish) {
+    await this.checkNetworksMatch();
+
+    return contract.getTokenCreator({
+      tokenId,
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
    * Gets the max supply
    * @returns BigNumberish
    */

--- a/sdks/open-format/test/token.test.ts
+++ b/sdks/open-format/test/token.test.ts
@@ -39,4 +39,10 @@ describe('sdk token', () => {
 
     expect(price).toBeInstanceOf(BigNumber);
   });
+
+  it('get the creator of a token', async () => {
+    const creator = await nft.getTokenCreator(0);
+
+    expect(typeof creator).toBe('string');
+  });
 });

--- a/sdks/open-format/test/token.test.ts
+++ b/sdks/open-format/test/token.test.ts
@@ -43,6 +43,6 @@ describe('sdk token', () => {
   it('get the creator of a token', async () => {
     const creator = await nft.getTokenCreator(0);
 
-    expect(typeof creator).toBe('string');
+    expect(creator).toBe('0x21b2Be9090D1d319e57B67c4B5d37bc5ec29a9d0');
   });
 });

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -9,6 +9,7 @@ export * from './useGetSecondaryCommissionPercentage';
 export * from './useGetTokenBalance';
 export * from './useGetTokenSalePrice';
 export * from './useGetTotalSupply';
+export * from './useGetTokenCreator';
 export * from './useMint';
 export * from './useMintWithCommission';
 export * from './useNFT';

--- a/sdks/react/src/hooks/useGetTokenCreator.tsx
+++ b/sdks/react/src/hooks/useGetTokenCreator.tsx
@@ -1,0 +1,16 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { BigNumberish } from 'ethers';
+import { useQuery } from 'react-query';
+
+/**
+ * Hook to get creator of a token
+ * @param {{ token: BigNumberish }} token - Token ID
+ * @returns
+ */
+export function useGetTokenCreator(nft: OpenFormatNFT, token: BigNumberish) {
+  const query = useQuery(['token-creator', token], () =>
+    nft.getTokenCreator(token)
+  );
+
+  return query;
+}

--- a/sdks/react/test/useGetTokenCreator.test.tsx
+++ b/sdks/react/test/useGetTokenCreator.test.tsx
@@ -1,0 +1,43 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { useMint, useNFT, useGetTokenCreator } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function Get({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { mint, data: mintData } = useMint(nft);
+  const { data } = useGetTokenCreator(nft, 0);
+
+  return (
+    <>
+      <button data-testid="mint" onClick={() => mint()}>
+        Mint
+      </button>
+
+      {mintData && (
+        <>
+          <span data-testid="mintData"></span>
+          {data && <span data-testid="getData">{data}</span>}
+        </>
+      )}
+    </>
+  );
+}
+
+describe('useGetTokenCreator', () => {
+  it('allows you to get the token creator', async () => {
+    render(
+      <DeployedTest>{({ address }) => <Get address={address} />}</DeployedTest>
+    );
+
+    const mintButton = await waitFor(() => screen.getByTestId('mint'));
+
+    mintButton.click();
+    await waitFor(() => screen.getByTestId('mintData'));
+    await waitFor(() => screen.getByTestId('getData'));
+
+    expect(screen.getByTestId('getData')).toHaveTextContent(
+      '0x21b2Be9090D1d319e57B67c4B5d37bc5ec29a9d0'
+    );
+  });
+});


### PR DESCRIPTION
# Get Token Creator

Introduces `getTokenCreator` into the SDK, as per the discussion thread #61.

```tsx
const nft = sdk.getNFT(contractAddress);
const creator = await nft.getTokenCreator(0);
```

```tsx
const nft = useNFT(address);
const { data } = useGetTokenCreator(nft, 0);
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
