### PR TITLE
Feature: Set Approved Minting Extension

### DIFF
--- a/.changeset/four-eggs-yawn.md
+++ b/.changeset/four-eggs-yawn.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Adds in functionality to allow you to set the approved minting extension

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -63,6 +63,24 @@ export async function setMintingPrice({
   return receipt;
 }
 
+export async function setApprovedMintingExtension({
+  extensionContractAddress,
+  contractAddress,
+  signer,
+}: ContractArgs & {
+  extensionContractAddress: string;
+}) {
+  const openFormat = getContract({ contractAddress, signer });
+
+  const tx = await openFormat.setApprovedMintingExtension(
+    extensionContractAddress
+  );
+
+  const receipt = await tx.wait();
+
+  return receipt;
+}
+
 export async function setRoyalties({
   contractAddress,
   signer,

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -59,6 +59,21 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   /**
+   * Sets the approved minting share extension
+   * @param {string} extensionContractAddress - The contract address of the approved minting extension
+   * @returns transaction
+   */
+  async setApprovedMintingExtension(extensionContractAddress: string) {
+    await this.checkNetworksMatch();
+
+    return contract.setApprovedMintingExtension({
+      extensionContractAddress,
+      contractAddress: this.address,
+      signer: this.signer,
+    });
+  }
+
+  /**
    * Setup royalties to be paid to an address
    * @param {Object} params
    * @param {number} params.royaltyReceiverAddress - address of the receiver of the royalties

--- a/sdks/open-format/test/mint.test.ts
+++ b/sdks/open-format/test/mint.test.ts
@@ -51,8 +51,7 @@ describe('sdk.mint()', () => {
 
   it('sets the approved minting extension', async () => {
     const receipt = await nft.setApprovedMintingExtension(
-      // Replace this with the correct address
-      '0x0000000000000000000000000000000000000000'
+      '0xf9D93537eC4c68ea7FDd841f17f2Df78204a21ff'
     );
 
     expect(receipt.status).toBe(1);

--- a/sdks/open-format/test/mint.test.ts
+++ b/sdks/open-format/test/mint.test.ts
@@ -48,4 +48,13 @@ describe('sdk.mint()', () => {
 
     expect(receipt.status).toBe(1);
   });
+
+  it('sets the approved minting extension', async () => {
+    const receipt = await nft.setApprovedMintingExtension(
+      // Replace this with the correct address
+      '0x0000000000000000000000000000000000000000'
+    );
+
+    expect(receipt.status).toBe(1);
+  });
 });

--- a/sdks/react/src/hooks/index.ts
+++ b/sdks/react/src/hooks/index.ts
@@ -17,6 +17,7 @@ export * from './useRawRequest';
 export * from './useRevenueSharingAllocation';
 export * from './useRoyalties';
 export * from './useSaleData';
+export * from './useSetApprovedMintingExtension';
 export * from './useSetMintingPrice';
 export * from './useSetMaxSupply';
 export * from './useSetPrimaryCommissionPercentage';

--- a/sdks/react/src/hooks/useSetApprovedMintingExtension.tsx
+++ b/sdks/react/src/hooks/useSetApprovedMintingExtension.tsx
@@ -1,0 +1,17 @@
+import { OpenFormatNFT } from '@simpleweb/open-format';
+import { useMutation } from 'react-query';
+
+export function useSetApprovedMintingExtension(nft: OpenFormatNFT) {
+  const { mutateAsync: setApprovedMintingExtension, ...mutation } = useMutation<
+    Awaited<ReturnType<typeof nft.setApprovedMintingExtension>>,
+    unknown,
+    Parameters<typeof nft.setApprovedMintingExtension>[0]
+  >(address => {
+    return nft.setApprovedMintingExtension(address);
+  });
+
+  return {
+    ...mutation,
+    setApprovedMintingExtension,
+  };
+}

--- a/sdks/react/test/useSetApprovedMintingExtension.test.tsx
+++ b/sdks/react/test/useSetApprovedMintingExtension.test.tsx
@@ -15,8 +15,7 @@ function Set({ address }: { address: string }) {
         data-testid="setApprovedMintingExtension"
         onClick={() => {
           setApprovedMintingExtension(
-            // Replace this with the correct address
-            '0x0000000000000000000000000000000000000000'
+            '0xf9D93537eC4c68ea7FDd841f17f2Df78204a21ff'
           );
         }}
       >

--- a/sdks/react/test/useSetApprovedMintingExtension.test.tsx
+++ b/sdks/react/test/useSetApprovedMintingExtension.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { useNFT, useSetApprovedMintingExtension } from '../src/hooks';
+import { DeployedTest, render, screen, waitFor } from '../src/utilities';
+
+function Set({ address }: { address: string }) {
+  const nft = useNFT(address);
+  const { setApprovedMintingExtension, data } = useSetApprovedMintingExtension(
+    nft
+  );
+
+  return (
+    <>
+      <button
+        data-testid="setApprovedMintingExtension"
+        onClick={() => {
+          setApprovedMintingExtension(
+            // Replace this with the correct address
+            '0x0000000000000000000000000000000000000000'
+          );
+        }}
+      >
+        Setup Revenue Sharing
+      </button>
+
+      {data && <div data-testid="approvedMintingExtensionData"></div>}
+    </>
+  );
+}
+
+describe('useSetApprovedMintingExtension', () => {
+  it('allows you to set the approved minting extension', async () => {
+    render(
+      <DeployedTest>{({ address }) => <Set address={address} />}</DeployedTest>
+    );
+
+    const set = await waitFor(() =>
+      screen.getByTestId('setApprovedMintingExtension')
+    );
+
+    set.click();
+    await waitFor(() => screen.getByTestId('approvedMintingExtensionData'));
+  });
+});


### PR DESCRIPTION
# Set Approved Minting Extension

Introduces `setApprovedMintingExtension` into the SDK, as per the discussion thread #61.

```tsx
const nft = sdk.getNFT(contractAddress);
const receipt = await nft.setApprovedMintingExtension();
```

```tsx
const nft = useNFT(address);
const { setApprovedMintingExtension } = useSetApprovedMintingExtension(nft);

() => setApprovedMintingExtension()
```

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
