### PR TITLE
Feature: Pass custom transaction parameters to deploy function

### DIFF
--- a/.changeset/grumpy-students-juggle.md
+++ b/.changeset/grumpy-students-juggle.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": minor
+"@simpleweb/open-format-react": minor
+---
+
+Allows for transaction arguments to be passed into the deploy method

--- a/examples/node-deploy/index.js
+++ b/examples/node-deploy/index.js
@@ -1,4 +1,5 @@
 import { OpenFormatSDK } from "@simpleweb/open-format";
+import { ethers } from "ethers";
 
 const sdk = new OpenFormatSDK({
   network: "mumbai",
@@ -7,13 +8,21 @@ const sdk = new OpenFormatSDK({
 
 console.log("Deploying...");
 
-const { transactionHash } = await sdk.deploy({
-  maxSupply: 100,
-  mintingPrice: 0.01,
-  name: "Test 1",
-  symbol: "TEST1",
-  url: "ipfs://"
-});
+const { transactionHash } = await sdk.deploy(
+  {
+    maxSupply: 100,
+    mintingPrice: 0.01,
+    name: "Test 1",
+    symbol: "TEST1",
+    url: "ipfs://"
+  }
+  // @dev uncomment to pass through transaction arguments.
+  // https://docs.ethers.io/v5/api/utils/transactions/#Transaction
+  // {
+  //   maxFeePerGas: ethers.BigNumber.from(60e9),
+  //   maxPriorityFeePerGas: ethers.BigNumber.from(60e9)
+  // }
+);
 
 console.log(
   `View on Polygonscan: https://mumbai.polygonscan.com/tx/${transactionHash}`

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -424,7 +424,7 @@ export async function deploy({
     nft.url,
     nft.maxSupply,
     ethers.utils.parseEther(nft.mintingPrice.toString()),
-    transactionArgs && { transactionArgs }
+    { ...transactionArgs }
   );
 
   const receipt = await contract.deployTransaction.wait();

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -1,8 +1,8 @@
 import base from '@simpleweb/open-format-contracts';
-import { ethers, BigNumberish, Signer } from 'ethers';
-import { NFTMetadata } from '../types';
+import { BigNumberish, ethers, Signer, Transaction } from 'ethers';
 import { OpenFormat } from '../contract-types';
 import isZeroAddress from '../helpers/zeroAddress';
+import { NFTMetadata } from '../types';
 
 type ContractArgs = {
   contractAddress: string;
@@ -406,9 +406,11 @@ export async function burn({
 export async function deploy({
   signer,
   nft,
+  transactionArgs,
 }: {
   signer: Signer;
   nft: NFTMetadata;
+  transactionArgs: Transaction;
 }) {
   const openFormatContract = new ethers.ContractFactory(
     base.abi,
@@ -421,7 +423,8 @@ export async function deploy({
     nft.symbol,
     nft.url,
     nft.maxSupply,
-    ethers.utils.parseEther(nft.mintingPrice.toString())
+    ethers.utils.parseEther(nft.mintingPrice.toString()),
+    { ...transactionArgs }
   );
 
   const receipt = await contract.deployTransaction.wait();

--- a/sdks/open-format/src/core/contract.ts
+++ b/sdks/open-format/src/core/contract.ts
@@ -410,7 +410,7 @@ export async function deploy({
 }: {
   signer: Signer;
   nft: NFTMetadata;
-  transactionArgs: Transaction;
+  transactionArgs?: Transaction;
 }) {
   const openFormatContract = new ethers.ContractFactory(
     base.abi,
@@ -424,7 +424,7 @@ export async function deploy({
     nft.url,
     nft.maxSupply,
     ethers.utils.parseEther(nft.mintingPrice.toString()),
-    { ...transactionArgs }
+    transactionArgs && { transactionArgs }
   );
 
   const receipt = await contract.deployTransaction.wait();

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -1,3 +1,4 @@
+import { Transaction } from 'ethers';
 import merge from 'lodash.merge';
 import {
   getProviderFromUrl,
@@ -54,7 +55,7 @@ export class OpenFormatSDK extends BaseContract {
    * @param {string} nft.url - storage URL
    * @returns transaction
    */
-  async deploy(nft: NFTMetadata) {
+  async deploy(nft: NFTMetadata, transactionArgs: Transaction) {
     invariant(this.signer, 'No signer set, cannot deploy');
 
     await this.checkNetworksMatch();
@@ -62,6 +63,7 @@ export class OpenFormatSDK extends BaseContract {
     const tx = await contract.deploy({
       signer: this.signer,
       nft,
+      transactionArgs,
     });
 
     return tx;

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -55,7 +55,7 @@ export class OpenFormatSDK extends BaseContract {
    * @param {string} nft.url - storage URL
    * @returns transaction
    */
-  async deploy(nft: NFTMetadata, transactionArgs: Transaction) {
+  async deploy(nft: NFTMetadata, transactionArgs?: Transaction) {
     invariant(this.signer, 'No signer set, cannot deploy');
 
     await this.checkNetworksMatch();
@@ -63,7 +63,7 @@ export class OpenFormatSDK extends BaseContract {
     const tx = await contract.deploy({
       signer: this.signer,
       nft,
-      transactionArgs,
+      ...(transactionArgs && { transactionArgs }),
     });
 
     return tx;

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -63,7 +63,7 @@ export class OpenFormatSDK extends BaseContract {
     const tx = await contract.deploy({
       signer: this.signer,
       nft,
-      ...(transactionArgs && { transactionArgs }),
+      transactionArgs,
     });
 
     return tx;

--- a/sdks/react/src/hooks/useDeploy.tsx
+++ b/sdks/react/src/hooks/useDeploy.tsx
@@ -1,19 +1,21 @@
 import { useMutation } from 'react-query';
+import { Transaction } from 'ethers';
 import { useOpenFormat } from '../provider';
 
 /**
  * Gets the deploy function from the sdk
+ * @param {Transaction} [transactionArgs]
  * @returns deploy function
  */
-export function useDeploy() {
+export function useDeploy(transactionArgs?: Transaction) {
   const { sdk } = useOpenFormat();
 
   const { mutateAsync, ...mutation } = useMutation<
     Awaited<ReturnType<typeof sdk.deploy>>,
     unknown,
-    Parameters<typeof sdk.deploy>
+    Parameters<typeof sdk.deploy>[0]
   >(data => {
-    return sdk.deploy(...data);
+    return sdk.deploy(data, transactionArgs);
   });
 
   return {

--- a/sdks/react/src/hooks/useDeploy.tsx
+++ b/sdks/react/src/hooks/useDeploy.tsx
@@ -11,9 +11,9 @@ export function useDeploy() {
   const { mutateAsync, ...mutation } = useMutation<
     Awaited<ReturnType<typeof sdk.deploy>>,
     unknown,
-    Parameters<typeof sdk.deploy>[0]
+    Parameters<typeof sdk.deploy>
   >(data => {
-    return sdk.deploy(data);
+    return sdk.deploy(...data);
   });
 
   return {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
I've updated the `deploy()` function so you can pass in Transaction arguments -https://docs.ethers.io/v5/api/utils/transactions/#Transaction

<!-- Why are these changes necessary? -->

**Why**:
Metamask and other wallet providers help calculate the correct `maxFeePerGas`, `maxPriorityFeePerGas` and `gasPrice` based on the current network conditions. However, in a node environment, there is no wallet provider (just a private key), so default gas values are set. These are sometimes too low when networks are congested resulting in transactions taking a long time to confirm or they just fail. 

<!-- How were these changes implemented? -->

**How**:
The `deploy()` function now accepts transaction arguments

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
