### PR TITLE
Lazy signer

### DIFF
--- a/.changeset/afraid-sloths-sort.md
+++ b/.changeset/afraid-sloths-sort.md
@@ -1,0 +1,6 @@
+---
+"@simpleweb/open-format": patch
+"@simpleweb/open-format-react": patch
+---
+
+Allow signer to be lazily set in useNFT

--- a/examples/react-next/pages/index.tsx
+++ b/examples/react-next/pages/index.tsx
@@ -2,6 +2,7 @@ import {
   ConnectButton,
   useDeploy,
   useMint,
+  useNFT,
   useRawRequest,
   useSaleData,
   useWallet
@@ -26,7 +27,11 @@ const Home: NextPage = () => {
     `
   });
 
-  const { deploy, data: deployedContract } = useDeploy();
+  const {
+    deploy,
+    isLoading: isDeploying,
+    data: deployedContract
+  } = useDeploy();
 
   async function handleDeploy() {
     try {
@@ -42,20 +47,6 @@ const Home: NextPage = () => {
     }
   }
 
-  const { mint } = useMint();
-
-  async function handleMint() {
-    try {
-      if (typeof deployedContract?.contractAddress !== "string") {
-        throw new Error("Contract address not sent");
-      }
-
-      await mint({ contractAddress: deployedContract.contractAddress });
-    } catch (error) {
-      console.log("handleDeploy", error);
-    }
-  }
-
   return (
     <div>
       <h1>Open Format React</h1>
@@ -66,14 +57,16 @@ const Home: NextPage = () => {
 
       {isConnected && (
         <div>
-          <button onClick={handleDeploy}>Deploy NFT</button>
+          <button onClick={handleDeploy}>
+            {isDeploying ? "Deploying..." : "Deploy"}
+          </button>
         </div>
       )}
 
       {deployedContract && (
-        <div>
-          <button onClick={handleMint}>Mint NFT</button>
-        </div>
+        <>
+          <Nft address={deployedContract.contractAddress} />
+        </>
       )}
 
       {saleData.isLoading ? (
@@ -90,5 +83,25 @@ const Home: NextPage = () => {
     </div>
   );
 };
+
+function Nft({ address }: { address: string }) {
+  const nft = useNFT(address);
+
+  const { mint } = useMint(nft);
+
+  async function handleMint() {
+    try {
+      await mint();
+    } catch (error) {
+      console.log("handleDeploy", error);
+    }
+  }
+  return (
+    <>
+      <p>NFT: {address}</p>
+      <button onClick={handleMint}>Mint</button>
+    </>
+  );
+}
 
 export default Home;

--- a/sdks/open-format/src/core/nft.ts
+++ b/sdks/open-format/src/core/nft.ts
@@ -1,4 +1,5 @@
 import { BigNumberish, providers, Signer } from 'ethers';
+import { invariant } from '../helpers/invariant';
 import { BaseContract } from './base';
 import * as contract from './contract';
 
@@ -7,9 +8,8 @@ import * as contract from './contract';
  */
 export class OpenFormatNFT extends BaseContract {
   address: string;
-  signer: Signer;
 
-  constructor(address: string, provider: providers.Provider, signer: Signer) {
+  constructor(address: string, provider: providers.Provider, signer?: Signer) {
     super(provider, signer);
     this.address = address;
     this.signer = signer;
@@ -20,6 +20,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns transaction
    */
   async mint() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.mint({
@@ -34,6 +36,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns transaction
    */
   async mintWithCommission(address: string) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.mintWithCommission({
@@ -49,6 +53,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns transaction
    */
   async setMintingPrice(price: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setMintingPrice({
@@ -64,6 +70,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns transaction
    */
   async setApprovedMintingExtension(extensionContractAddress: string) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setApprovedMintingExtension({
@@ -84,6 +92,8 @@ export class OpenFormatNFT extends BaseContract {
     royaltyReceiverAddress: string;
     royaltyPercentage: number;
   }) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setRoyalties({
@@ -100,6 +110,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async getRoyalties({ salePrice }: { salePrice: number }) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getRoyalties({
@@ -128,6 +140,8 @@ export class OpenFormatNFT extends BaseContract {
     }[];
     holderPercentage: BigNumberish;
   }) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setupRevenueSharing({
@@ -151,6 +165,8 @@ export class OpenFormatNFT extends BaseContract {
       share: BigNumberish;
     }[]
   ) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.allocateRevenueShares({
@@ -166,6 +182,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns BigNumber
    */
   async getCollaboratorBalance(address: string) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getCollaboratorBalance({
@@ -181,6 +199,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async withdrawCollaboratorFunds(address: string) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.withdrawCollaboratorFunds({
@@ -196,6 +216,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns BigNumber
    */
   async getTokenBalance(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getTokenBalance({
@@ -211,6 +233,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async withdrawTokenFunds(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.withdrawTokenFunds({
@@ -226,6 +250,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async setPrimaryCommissionPercent(percent: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setPrimaryCommissionPercent({
@@ -240,6 +266,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns percent
    */
   async getPrimaryCommissionPercent() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getPrimaryCommissionPercent({
@@ -254,6 +282,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async setSecondaryCommissionPercent(percent: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setSecondaryCommissionPercent({
@@ -268,6 +298,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns percent
    */
   async getSecondaryCommissionPercent() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getSecondaryCommissionPercent({
@@ -290,6 +322,8 @@ export class OpenFormatNFT extends BaseContract {
     tokenId: BigNumberish;
     price: BigNumberish;
   }) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setTokenSalePrice({
@@ -306,6 +340,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns price
    */
   async getTokenSalePrice(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getTokenSalePrice({
@@ -321,6 +357,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns creator
    */
   async getTokenCreator(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getTokenCreator({
@@ -335,6 +373,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns BigNumberish
    */
   async getMaxSupply() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getMaxSupply({
@@ -349,6 +389,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns transaction
    */
   async setMaxSupply(amount: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.setMaxSupply({
@@ -363,6 +405,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns BigNumberish
    */
   async getTotalSupply() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.getTotalSupply({
@@ -378,6 +422,8 @@ export class OpenFormatNFT extends BaseContract {
    * @returns
    */
   async buy(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.buy({
@@ -401,6 +447,8 @@ export class OpenFormatNFT extends BaseContract {
     tokenId: BigNumberish;
     address: string;
   }) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.buyWithCommission({
@@ -412,6 +460,8 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   async togglePauseState() {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.togglePauseState({
@@ -421,6 +471,8 @@ export class OpenFormatNFT extends BaseContract {
   }
 
   async burn(tokenId: BigNumberish) {
+    invariant(this.signer, 'No signer set');
+
     await this.checkNetworksMatch();
 
     return contract.burn({

--- a/sdks/open-format/src/core/sdk.ts
+++ b/sdks/open-format/src/core/sdk.ts
@@ -1,5 +1,6 @@
 import { Transaction } from 'ethers';
 import merge from 'lodash.merge';
+import { invariant } from '../helpers/invariant';
 import {
   getProviderFromUrl,
   getProviderUrl,
@@ -10,12 +11,6 @@ import { BaseContract } from './base';
 import * as contract from './contract';
 import { OpenFormatNFT } from './nft';
 import * as subgraph from './subgraph';
-
-function invariant(condition: any, message: string): asserts condition {
-  if (!condition) {
-    throw new Error(message);
-  }
-}
 
 /**
  * Creates a new instance of the Open Format SDK
@@ -75,7 +70,6 @@ export class OpenFormatSDK extends BaseContract {
    * @returns OpenFormatNFT
    */
   getNFT(address: string) {
-    invariant(this.signer, 'No signer set, cannot get NFT');
     return new OpenFormatNFT(address, this.provider, this.signer);
   }
 

--- a/sdks/open-format/src/helpers/invariant.ts
+++ b/sdks/open-format/src/helpers/invariant.ts
@@ -1,0 +1,5 @@
+export function invariant(condition: any, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/sdks/react/src/hooks/useNFT.tsx
+++ b/sdks/react/src/hooks/useNFT.tsx
@@ -1,7 +1,23 @@
-import { useRef } from 'react';
+import { useConnectWallet } from '@web3-onboard/react';
+import { ethers } from 'ethers';
+import { useEffect, useRef } from 'react';
 import { useOpenFormat } from '../provider';
 
 export function useNFT(address: string) {
+  const [{ wallet }] = useConnectWallet();
   const { sdk } = useOpenFormat();
-  return useRef(sdk.getNFT(address)).current;
+
+  const nft = useRef(sdk.getNFT(address));
+
+  useEffect(() => {
+    if (wallet) {
+      nft.current.signer = new ethers.providers.Web3Provider(
+        wallet.provider
+      ).getSigner();
+    } else {
+      nft.current.signer = undefined;
+    }
+  }, [wallet]);
+
+  return nft.current;
 }


### PR DESCRIPTION
Allows the signer to be set lazily when creating a new NFT class. This is because you can use the `useNFT` hook before a wallet might be connected (even if it is reconnecting from a page reload) but you want to wait to get the signer before you throw an error.

The Next demo app has also been updated to use the new `useNFT` hook.

This fixes #79 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
