### PR TITLE
Hotfix: Adds the ethers dependency to the `node-deploy` example

### DIFF
--- a/examples/node-deploy/package-lock.json
+++ b/examples/node-deploy/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@simpleweb/open-format": "^0.1.2"
+        "@simpleweb/open-format": "^0.4.0",
+        "ethers": "^5.6.9"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -26,7 +27,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -53,7 +53,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -78,7 +77,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -101,7 +99,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -124,7 +121,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1"
       }
@@ -143,7 +139,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/properties": "^5.6.0"
@@ -163,7 +158,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -184,7 +178,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -203,7 +196,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2"
       }
@@ -222,7 +214,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "^5.6.3",
         "@ethersproject/abstract-provider": "^5.6.1",
@@ -250,7 +241,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -276,7 +266,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/basex": "^5.6.1",
@@ -306,7 +295,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -337,7 +325,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "js-sha3": "0.8.0"
@@ -356,8 +343,7 @@
           "type": "individual",
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@ethersproject/networks": {
       "version": "5.6.4",
@@ -373,7 +359,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -392,7 +377,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/sha2": "^5.6.1"
@@ -412,7 +396,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -431,7 +414,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -469,7 +451,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -489,7 +470,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -509,7 +489,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -530,7 +509,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -554,7 +532,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -578,7 +555,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/constants": "^5.6.1",
@@ -599,7 +575,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -626,7 +601,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/constants": "^5.6.1",
@@ -647,7 +621,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -680,7 +653,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/base64": "^5.6.1",
         "@ethersproject/bytes": "^5.6.1",
@@ -703,7 +675,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.6.1",
@@ -713,9 +684,9 @@
       }
     },
     "node_modules/@simpleweb/open-format": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@simpleweb/open-format/-/open-format-0.1.2.tgz",
-      "integrity": "sha512-krr18f+k7g3DEEjDJv0CMzOoiQfu/+/d/H7AwnXgBs3BG8yw+yzw1AXA3UEmgHZVnXYo8RRfM3mh8KigMVZVOg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@simpleweb/open-format/-/open-format-0.4.0.tgz",
+      "integrity": "sha512-QEAWrta/3juUT4xgOz4KNa1LGSgiJppruLU0Be86+5MuOip9BCLg4g94IN4lPgMPYY8rFuhNxX1jReXXOe9ohA==",
       "dependencies": {
         "@simpleweb/open-format-contracts": "^0.3.0",
         "graphql": "^16.5.0",
@@ -737,8 +708,7 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "peer": true
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -748,20 +718,17 @@
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "peer": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-      "peer": true
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "peer": true
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -794,7 +761,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -808,8 +774,7 @@
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "peer": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/ethers": {
       "version": "5.6.9",
@@ -825,7 +790,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.6.4",
         "@ethersproject/abstract-provider": "5.6.1",
@@ -908,7 +872,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -918,7 +881,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -928,14 +890,12 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "peer": true
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -964,14 +924,12 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "peer": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "peer": true
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -995,8 +953,7 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "peer": true
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -1021,7 +978,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -1044,7 +1000,6 @@
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.6.4.tgz",
       "integrity": "sha512-TTeZUlCeIHG6527/2goZA6gW5F8Emoc7MrZDC7hhP84aRGvW3TEdTnZR08Ls88YXM1m2SuK42Osw/jSi3uO8gg==",
-      "peer": true,
       "requires": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -1061,7 +1016,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.6.1.tgz",
       "integrity": "sha512-BxlIgogYJtp1FS8Muvj8YfdClk3unZH0vRMVX791Z9INBNT/kuACZ9GzaY1Y4yFq+YSy6/w4gzj3HCRKrK9hsQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -1076,7 +1030,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.6.2.tgz",
       "integrity": "sha512-n1r6lttFBG0t2vNiI3HoWaS/KdOt8xyDjzlP2cuevlWLG6EX0OwcKLyG/Kp/cuwNxdy/ous+R/DEMdTUwWQIjQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -1089,7 +1042,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.6.1.tgz",
       "integrity": "sha512-uOgF0kS5MJv9ZvCz7x6T2EXJSzotiybApn4XlOgoTX0xdtyVIJ7pF+6cGPxiEq/dpBiTfMiw7Yc81JcwhSYA0Q==",
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -1102,7 +1054,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.6.1.tgz",
       "integrity": "sha512-qB76rjop6a0RIYYMiB4Eh/8n+Hxu2NIZm8S/Q7kNo5pmZfXhHGHmS4MinUainiBC54SCyRnwzL+KZjj8zbsSsw==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1"
       }
@@ -1111,7 +1062,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.6.1.tgz",
       "integrity": "sha512-a52MkVz4vuBXR06nvflPMotld1FJWSj2QT0985v7P/emPZO00PucFAkbcmq2vpVU7Ts7umKiSI6SppiLykVWsA==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/properties": "^5.6.0"
@@ -1121,7 +1071,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.6.2.tgz",
       "integrity": "sha512-v7+EEUbhGqT3XJ9LMPsKvXYHFc8eHxTowFCG/HgJErmq4XHJ2WR7aeyICg3uTOAQ7Icn0GFHAohXEhxQHq4Ubw==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -1132,7 +1081,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.6.1.tgz",
       "integrity": "sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==",
-      "peer": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -1141,7 +1089,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.6.1.tgz",
       "integrity": "sha512-QSq9WVnZbxXYFftrjSjZDUshp6/eKp6qrtdBtUCm0QxCV5z1fG/w3kdlcsjMCQuQHUnAclKoK7XpXMezhRDOLg==",
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2"
       }
@@ -1150,7 +1097,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.6.2.tgz",
       "integrity": "sha512-hguUA57BIKi6WY0kHvZp6PwPlWF87MCeB4B7Z7AbUpTxfFXFdn/3b0GmjZPagIHS+3yhcBJDnuEfU4Xz+Ks/8g==",
-      "peer": true,
       "requires": {
         "@ethersproject/abi": "^5.6.3",
         "@ethersproject/abstract-provider": "^5.6.1",
@@ -1168,7 +1114,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.6.1.tgz",
       "integrity": "sha512-L1xAHurbaxG8VVul4ankNX5HgQ8PNCTrnVXEiFnE9xoRnaUcgfD12tZINtDinSllxPLCtGwguQxJ5E6keE84pA==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -1184,7 +1129,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.6.2.tgz",
       "integrity": "sha512-tERxW8Ccf9CxW2db3WsN01Qao3wFeRsfYY9TCuhmG0xNpl2IO8wgXU3HtWIZ49gUWPggRy4Yg5axU0ACaEKf1Q==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/basex": "^5.6.1",
@@ -1204,7 +1148,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.6.1.tgz",
       "integrity": "sha512-KfyJ6Zwz3kGeX25nLihPwZYlDqamO6pfGKNnVMWWfEVVp42lTfCZVXXy5Ie8IZTN0HKwAngpIPi7gk4IJzgmqQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.6.2",
         "@ethersproject/address": "^5.6.1",
@@ -1225,7 +1168,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.6.1.tgz",
       "integrity": "sha512-bB7DQHCTRDooZZdL3lk9wpL0+XuG3XLGHLh3cePnybsO3V0rdCAOQGpn/0R3aODmnTOOkCATJiD2hnL+5bwthA==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "js-sha3": "0.8.0"
@@ -1234,14 +1176,12 @@
     "@ethersproject/logger": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.6.0.tgz",
-      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==",
-      "peer": true
+      "integrity": "sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg=="
     },
     "@ethersproject/networks": {
       "version": "5.6.4",
       "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.6.4.tgz",
       "integrity": "sha512-KShHeHPahHI2UlWdtDMn2lJETcbtaJge4k7XSjDR9h79QTd6yQJmv6Cp2ZA4JdqWnhszAOLSuJEd9C0PRw7hSQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -1250,7 +1190,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.6.1.tgz",
       "integrity": "sha512-k4gRQ+D93zDRPNUfmduNKq065uadC2YjMP/CqwwX5qG6R05f47boq6pLZtV/RnC4NZAYOPH1Cyo54q0c9sshRQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/sha2": "^5.6.1"
@@ -1260,7 +1199,6 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.6.0.tgz",
       "integrity": "sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==",
-      "peer": true,
       "requires": {
         "@ethersproject/logger": "^5.6.0"
       }
@@ -1269,7 +1207,6 @@
       "version": "5.6.8",
       "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.8.tgz",
       "integrity": "sha512-Wf+CseT/iOJjrGtAOf3ck9zS7AgPmr2fZ3N97r4+YXN3mBePTG2/bJ8DApl9mVwYL+RpYbNxMEkEp4mPGdwG/w==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -1297,7 +1234,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.6.1.tgz",
       "integrity": "sha512-/wtPNHwbmng+5yi3fkipA8YBT59DdkGRoC2vWk09Dci/q5DlgnMkhIycjHlavrvrjJBkFjO/ueLyT+aUDfc4lA==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -1307,7 +1243,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.6.1.tgz",
       "integrity": "sha512-uYjmcZx+DKlFUk7a5/W9aQVaoEC7+1MOBgNtvNg13+RnuUwT4F0zTovC0tmay5SmRslb29V1B7Y5KCri46WhuQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0"
@@ -1317,7 +1252,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.6.1.tgz",
       "integrity": "sha512-5K2GyqcW7G4Yo3uenHegbXRPDgARpWUiXc6RiF7b6i/HXUoWlb7uCARh7BAHg7/qT/Q5ydofNwiZcim9qpjB6g==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -1328,7 +1262,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.6.2.tgz",
       "integrity": "sha512-jVbu0RuP7EFpw82vHcL+GP35+KaNruVAZM90GxgQnGqB6crhBqW/ozBfFvdeImtmb4qPko0uxXjn8l9jpn0cwQ==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/logger": "^5.6.0",
@@ -1342,7 +1275,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.6.1.tgz",
       "integrity": "sha512-KWqVLkUUoLBfL1iwdzUVlkNqAUIFMpbbeH0rgCfKmJp0vFtY4AsaN91gHKo9ZZLkC4UOm3cI3BmMV4N53BOq4g==",
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/bytes": "^5.6.1",
@@ -1356,7 +1288,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.6.1.tgz",
       "integrity": "sha512-2X1Lgk6Jyfg26MUnsHiT456U9ijxKUybz8IM1Vih+NJxYtXhmvKBcHOmvGqpFSVJ0nQ4ZCoIViR8XlRw1v/+Cw==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/constants": "^5.6.1",
@@ -1367,7 +1298,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.6.2.tgz",
       "integrity": "sha512-BuV63IRPHmJvthNkkt9G70Ullx6AcM+SDc+a8Aw/8Yew6YwT51TcBKEp1P4oOQ/bP25I18JJr7rcFRgFtU9B2Q==",
-      "peer": true,
       "requires": {
         "@ethersproject/address": "^5.6.1",
         "@ethersproject/bignumber": "^5.6.2",
@@ -1384,7 +1314,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.6.1.tgz",
       "integrity": "sha512-rEfSEvMQ7obcx3KWD5EWWx77gqv54K6BKiZzKxkQJqtpriVsICrktIQmKl8ReNToPeIYPnFHpXvKpi068YFZXw==",
-      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.6.2",
         "@ethersproject/constants": "^5.6.1",
@@ -1395,7 +1324,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.6.2.tgz",
       "integrity": "sha512-lrgh0FDQPuOnHcF80Q3gHYsSUODp6aJLAdDmDV0xKCN/T7D99ta1jGVhulg3PY8wiXEngD0DfM0I2XKXlrqJfg==",
-      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.1",
         "@ethersproject/abstract-signer": "^5.6.2",
@@ -1418,7 +1346,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.6.1.tgz",
       "integrity": "sha512-/vSyzaQlNXkO1WV+RneYKqCJwualcUdx/Z3gseVovZP0wIlOFcCE1hkRhKBH8ImKbGQbMl9EAAyJFrJu7V0aqA==",
-      "peer": true,
       "requires": {
         "@ethersproject/base64": "^5.6.1",
         "@ethersproject/bytes": "^5.6.1",
@@ -1431,7 +1358,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.6.1.tgz",
       "integrity": "sha512-wiPRgBpNbNwCQFoCr8bcWO8o5I810cqO6mkdtKfLKFlLxeCWcnzDi4Alu8iyNzlhYuS9npCwivMbRWF19dyblw==",
-      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.6.1",
         "@ethersproject/hash": "^5.6.1",
@@ -1441,9 +1367,9 @@
       }
     },
     "@simpleweb/open-format": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@simpleweb/open-format/-/open-format-0.1.2.tgz",
-      "integrity": "sha512-krr18f+k7g3DEEjDJv0CMzOoiQfu/+/d/H7AwnXgBs3BG8yw+yzw1AXA3UEmgHZVnXYo8RRfM3mh8KigMVZVOg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@simpleweb/open-format/-/open-format-0.4.0.tgz",
+      "integrity": "sha512-QEAWrta/3juUT4xgOz4KNa1LGSgiJppruLU0Be86+5MuOip9BCLg4g94IN4lPgMPYY8rFuhNxX1jReXXOe9ohA==",
       "requires": {
         "@simpleweb/open-format-contracts": "^0.3.0",
         "graphql": "^16.5.0",
@@ -1459,8 +1385,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "peer": true
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1470,20 +1395,17 @@
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
-      "peer": true
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-      "peer": true
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "peer": true
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -1510,7 +1432,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "peer": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -1524,8 +1445,7 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "peer": true
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -1533,7 +1453,6 @@
       "version": "5.6.9",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.9.tgz",
       "integrity": "sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==",
-      "peer": true,
       "requires": {
         "@ethersproject/abi": "5.6.4",
         "@ethersproject/abstract-provider": "5.6.1",
@@ -1601,7 +1520,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -1611,7 +1529,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "peer": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -1621,14 +1538,12 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "peer": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "peer": true
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -1651,14 +1566,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "peer": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "peer": true
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -1671,8 +1584,7 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "peer": true
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "tr46": {
       "version": "0.0.3",
@@ -1697,7 +1609,6 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "peer": true,
       "requires": {}
     }
   }

--- a/examples/node-deploy/package.json
+++ b/examples/node-deploy/package.json
@@ -11,6 +11,7 @@
   "author": "Benjamin Reid",
   "license": "ISC",
   "dependencies": {
-    "@simpleweb/open-format": "^0.1.2"
+    "@simpleweb/open-format": "^0.4.0",
+    "ethers": "^5.6.9"
   }
 }


### PR DESCRIPTION
# Overview

Fixes #41 

* Updates the version of `@simpleweb/open-format` being used to latest version.
* Removes the `package-lock.json` and replaces it with `yarn.lock`.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
