### PR TITLE
Hotfix: Fixes the edit docs links in the docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+const EDIT_LINK = "https://github.com/simpleweb/open-format/tree/main/website";
 const GITHUB_LINK = "https://github.com/simpleweb/open-format";
 const TWITTER_LINK = "https://twitter.com/simpleweb";
 const DISCORD_LINK = "https://discord.gg/8WV52tVqbZ";
@@ -36,7 +37,7 @@ const config = {
         docs: {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: GITHUB_LINK
+          editUrl: EDIT_LINK
         },
         blog: false,
         theme: {


### PR DESCRIPTION
# Overview

* The "Edit this page" links are broken in the documentation. This pull requests fixes the configuration to ensure those links are not broken.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Code complete
- [ ] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
