### PR TITLE
Docs

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,1 +1,0 @@
-root: ./docs/

--- a/docs/docs/quickstart/react.mdx
+++ b/docs/docs/quickstart/react.mdx
@@ -227,14 +227,15 @@ function MyComponent() {
 Once you have deployed a contract you can then mint NFTs from it. The `contractAddress` can be accessed when deploying a contract `const { contractAddress } = await deploy()`.
 
 ```tsx
-import { useMint } from '@simpleweb/open-format-react';
+import { useMint, useNFT } from '@simpleweb/open-format-react';
 
 function MyComponent() {
-  const { mint } = useMint();
+  const nft = useNFT('0x...');
+  const { mint } = useMint(nft);
 
   return (
     <>
-      <button onClick={() => mint({ contractAddress: '0x...' })}>
+      <button onClick={() => mint()}>
         Mint NFT
       </button>
     </>


### PR DESCRIPTION
Small update to the docs regarding the usage of `useMint` and removes the gitbook reference.

Couldn't see much else code wise, all looked good 👍
