### PR TITLE
Fix automatic connection

### DIFF
--- a/.changeset/sharp-crews-sing.md
+++ b/.changeset/sharp-crews-sing.md
@@ -1,0 +1,5 @@
+---
+"@simpleweb/open-format-react": patch
+---
+
+Fixes automatic connection issue

--- a/sdks/react/src/provider.tsx
+++ b/sdks/react/src/provider.tsx
@@ -2,13 +2,7 @@ import { OpenFormatSDK, SDKOptions } from '@simpleweb/open-format';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConnectKitProvider } from 'connectkit';
 import React, { createContext, useContext, useEffect, useRef } from 'react';
-import {
-  useAccount,
-  useConnect,
-  useSigner,
-  Connector,
-  WagmiConfig,
-} from 'wagmi';
+import { Connector, useConnect, useSigner, WagmiConfig } from 'wagmi';
 import { wagmiClient } from './wagmi-client';
 
 const OpenFormatContext = createContext<{ sdk: OpenFormatSDK } | undefined>(
@@ -51,19 +45,22 @@ function InnerProvider({
   children: React.ReactNode;
   config?: SDKOptions;
 }) {
-  const { isDisconnected } = useAccount();
   const { connect, connectors } = useConnect();
   const sdk = useRef(new OpenFormatSDK(config));
 
   const { data: signer } = useSigner();
 
   useEffect(() => {
-    const wallet = JSON.parse(localStorage.getItem('wagmi.wallet') ?? '');
+    const wallet = JSON.parse(localStorage.getItem('wagmi.wallet') ?? '""');
+    const previouslyConnected = JSON.parse(
+      localStorage.getItem('wagmi.connected') ?? 'false'
+    );
+
     const connector = connectors.find(
       (connector: Connector) => wallet === connector.id
     );
 
-    if (wallet && isDisconnected) {
+    if (wallet && previouslyConnected) {
       connect({ connector });
     }
   }, []);


### PR DESCRIPTION
**What**:

Fixes an error that was being thrown when local storage was empty and fixes another issue which would make wallets re-connect if you had disconnected.

**Why**:

This was throwing an error, it was essentially parsing nothing.

```tsx
const wallet = JSON.parse(localStorage.getItem('wagmi.wallet') ?? '');
```

And `isDisconnected` was always `true` initially, so if "wagmi.wallet" is present in storage but you were actually disconnected, it would re-connect anyway.

**How**:

We are now checking against another locally stored property, "wagmi.connected" which is the correct state of connection.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
